### PR TITLE
fix: namespaces internal-system not found

### DIFF
--- a/src/constructs/common-helm-charts.ts
+++ b/src/constructs/common-helm-charts.ts
@@ -62,34 +62,6 @@ export class CommonHelmCharts extends Construct {
       });
     }
 
-    // if (props.iamPolicyPath != undefined) {
-    //   if(props.serviceAccounts != undefined) {
-    //     props.serviceAccounts.forEach((sa,index) => {
-    //       let serviceAccount = new eks.ServiceAccount(this,sa,{
-    //         namespace: namespace,
-    //         name: sa,
-    //         cluster: props.cluster
-    //       });
-    //       const policy = JSON.parse(fs.readFileSync(path.join(__dirname, props.iamPolicyPath[index]), 'utf8'));
-    //       for (const statement of policy.Statement) {
-    //         serviceAccount.addToPrincipalPolicy(iam.PolicyStatement.fromJson(statement));
-    //       }
-    //     })
-    //   } else {
-
-    //   }
-    //   serviceAccounts = new eks.ServiceAccount(this, `${props.helmProps.chartName}-sa`, { namespace, name: `${props.helmProps.chartName}`, cluster: props.cluster });
-    //   const policy = JSON.parse(fs.readFileSync(path.join(__dirname, props.iamPolicyPath), 'utf8'));
-    //   for (const statement of policy.Statement) {
-    //     serviceAccounts.addToPrincipalPolicy(iam.PolicyStatement.fromJson(statement));
-    //   }
-    // }
-
-    // console.log(`serviceAccount Name is ${serviceAccounts?.serviceAccountName}`);
-    // policy.Statement.forEach((statement) => {
-    //   serviceAccount.addToPrincipalPolicy(iam.PolicyStatement.fromJson(statement));
-    // });
-
     if (props.helmProps.helmRepository == undefined && props.helmProps.localHelmChart == undefined ) {
       throw new Error(
         'You cannot reference this property',

--- a/src/constructs/eks-cluster.ts
+++ b/src/constructs/eks-cluster.ts
@@ -526,8 +526,7 @@ export class EKSCluster extends Construct {
           chartReleaseName: 'private-external-dns',
           chartVersion: '1.9.0',
           helmRepository: 'https://kubernetes-sigs.github.io/external-dns/',
-          namespace: 'internal-system',
-          createNamespace: true,
+          namespace: 'kube-system',
           helmValues: {
             extraArgs: [
               '--aws-zone-type=private',
@@ -548,8 +547,7 @@ export class EKSCluster extends Construct {
           chartReleaseName: 'public-external-dns',
           chartVersion: '1.9.0',
           helmRepository: 'https://kubernetes-sigs.github.io/external-dns/',
-          namespace: 'internal-system',
-          createNamespace: true,
+          namespace: 'kube-system',
           helmValues: {
             extraArgs: [
               '--aws-zone-type=public',
@@ -569,8 +567,7 @@ export class EKSCluster extends Construct {
           chartName: 'cluster-autoscaler',
           chartVersion: '9.18.0',
           helmRepository: 'https://kubernetes.github.io/autoscaler',
-          namespace: 'internal-system',
-          createNamespace: true,
+          namespace: 'kube-system',
           helmValues: {
             autoDiscovery: {
               clusterName: clusterName,


### PR DESCRIPTION
we create the service account before we create the namespace using the helm custom resource
this makes the creation of the service account fail because the namespace does not exist

Received response status [FAILED] from custom resource. Message returned: Error: b Error from server (NotFound): error when creating "/tmp/manifest.yaml": namespaces "internal-system" not found