### PR TITLE
feat: opt-in deletion protection for cluster control plane log group

### DIFF
--- a/src/constructs/eks-cluster.ts
+++ b/src/constructs/eks-cluster.ts
@@ -4,6 +4,7 @@ import * as eks from 'aws-cdk-lib/aws-eks';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
 import { Construct } from 'constructs';
 import { CommonHelmCharts, StandardHelmProps } from './common-helm-charts';
 import { AwsEfsCsiAddon, CoreDnsAddon, KubeProxyAddon, MountpointS3CsiAddon } from './core-addon';
@@ -77,6 +78,18 @@ export interface ClusterConfig {
   readonly debugLogs?: boolean;
   readonly deprecateClusterAutoScaler?: boolean;
   readonly skipExternalDNS?: boolean;
+  /**
+   * Enable deletion protection on the cluster's control plane CloudWatch log group
+   * (/aws/eks/<clusterName>/cluster), guarding it against accidental deletion.
+   * @default false
+   */
+  readonly logGroupDeletionProtection?: boolean;
+  /**
+   * Retention period for the cluster's control plane CloudWatch log group.
+   * Only applied when `logGroupDeletionProtection` is enabled.
+   * @default logs.RetentionDays.INFINITE
+   */
+  readonly logGroupRetentionDays?: logs.RetentionDays;
 }
 
 export interface DefaultCommonComponents {
@@ -200,6 +213,19 @@ export class EKSCluster extends Construct {
           ],
     });
 
+    if (props.clusterConfig.logGroupDeletionProtection) {
+      // RetentionDays.INFINITE (9999) is an L2 sentinel meaning "never expire" and
+      // is not itself a valid CloudFormation retention value, so it must be omitted.
+      const retentionInDays = props.clusterConfig.logGroupRetentionDays === logs.RetentionDays.INFINITE
+        ? undefined
+        : props.clusterConfig.logGroupRetentionDays;
+      const clusterLogGroup = new logs.CfnLogGroup(this, 'ClusterLogGroup', {
+        logGroupName: `/aws/eks/${props.clusterConfig.clusterName}/cluster`,
+        retentionInDays,
+      });
+      clusterLogGroup.addPropertyOverride('DeletionProtection', true);
+      clusterLogGroup.node.addDependency(this.cluster);
+    }
 
     var createdNamespaces: eks.KubernetesManifest[] = [];
 


### PR DESCRIPTION
## Summary
- Adds opt-in `clusterConfig.logGroupDeletionProtection` and `clusterConfig.logGroupRetentionDays` to `ClusterConfig`.
- When `logGroupDeletionProtection` is `true`, `EKSCluster` now creates/manages the control plane log group (`/aws/eks/<clusterName>/cluster`) with `DeletionProtection` set, guarding it against accidental deletion (e.g. via console or `aws logs delete-log-group`).
- Retention defaults to infinite (matches current behavior) unless `logGroupRetentionDays` is set. Passing `logs.RetentionDays.INFINITE` explicitly is handled correctly (that enum sentinel isn't a valid literal for CloudFormation, so it's translated to "omit the property").
- Fully backward compatible — both fields are optional and off by default, so existing consumers see no behavior change.

Motivated by a security finding on `sib-infra-cdk-prod-eks`: EKS cluster logs were forwarded to CloudWatch but the log group had no deletion protection, risking loss of audit/monitoring data.

## Test plan
- [x] `tsc --noEmit` passes cleanly
- [ ] Consume this branch from `sib-infra-cdk-prod-eks`, `cdk synth`, confirm the `AWS::Logs::LogGroup` resource has `DeletionProtection: true` and correct `LogGroupName`
- [ ] `cdk diff`/`deploy` against SIB-PROD to confirm no disruption to existing control plane logging